### PR TITLE
Disconnect from vCenter after check

### DIFF
--- a/check_vsphere/check_vsphere.ps1
+++ b/check_vsphere/check_vsphere.ps1
@@ -255,4 +255,5 @@ if($ShowPercentFree) {
 }
 
 Write-Host $outputMessage
+Disconnect-VIServer -Server $Server -Confirm:$false | Out-Null
 Exit $exitCode


### PR DESCRIPTION
Just a quick minor change: Disconnect from the queried vCenter to avoid opening many sessions to the vCenter. I don't know if that will cause issues some day, but at least your vSphere admin won't like it too much. :)